### PR TITLE
Walkbox minimal support

### DIFF
--- a/space.go
+++ b/space.go
@@ -168,6 +168,20 @@ func (p Positionf) Move(to Positionf, speed Positionf) Positionf {
 	return p
 }
 
+// CrossProduct calculates the cross product of the vectors formed by three consecutive vertices of a polygon.
+func (p *Positionf) CrossProduct(p1, p2 *Positionf) float32 {
+	return (p1.X-p.X)*(p2.Y-p1.Y) - (p1.Y-p.Y)*(p2.X-p1.X)
+}
+
+// IsIntersecting calculate the x-coordinate of the intersection of the ray with the line segment (Ray-Casting method).
+func (p *Positionf) IsIntersecting(p1, p2 *Positionf) bool {
+	if (p1.Y > p.Y) != (p2.Y > p.Y) {
+		return p.X < (p2.X-p1.X)*(p.Y-p1.Y)/(p2.Y-p1.Y)+p1.X
+	}
+
+	return false
+}
+
 // Size represents a 2D size.
 type Size struct {
 	W, H int

--- a/space.go
+++ b/space.go
@@ -168,12 +168,12 @@ func (p Positionf) Move(to Positionf, speed Positionf) Positionf {
 	return p
 }
 
-// CrossProduct calculates the cross product of the vectors formed by three consecutive vertices of a polygon.
+// CrossProduct calculates the 2D cross product (determinant) of vectors p->p1 and p1->p2 to determine their orientation.
 func (p *Positionf) CrossProduct(p1, p2 *Positionf) float32 {
 	return (p1.X-p.X)*(p2.Y-p1.Y) - (p1.Y-p.Y)*(p2.X-p1.X)
 }
 
-// IsIntersecting calculate the x-coordinate of the intersection of the ray with the line segment (Ray-Casting method).
+// IsIntersecting checks if a horizontal ray from point p intersects the line segment p1->p2 (Ray-Casting method).
 func (p *Positionf) IsIntersecting(p1, p2 *Positionf) bool {
 	if (p1.Y > p.Y) != (p2.Y > p.Y) {
 		return p.X < (p2.X-p1.X)*(p.Y-p1.Y)/(p2.Y-p1.Y)+p1.X

--- a/walkbox.go
+++ b/walkbox.go
@@ -1,0 +1,105 @@
+package pctk
+
+import "log"
+
+const (
+	// MinPolygonVertices defines the minimum number of vertices to form a polygon.
+	MinPolygonVertices = 3
+)
+
+// Walkbox refers to a convex polygonal area that defines the walkable space for actors.
+type WalkBox struct {
+	WalkBoxID string
+	Enabled   bool
+	Vertices  []*Position
+	// TODO: Scale float32
+}
+
+// NewWalkBox creates a new WalkBox with the given ID and vertices.
+// It ensures the polygon formed by the vertices is convex. If not, it will cause a panic.
+// Why convex? Because you can draw a straight line/path between any two vertices inside the polygon
+// without needing to implement complex pathfinding algorithms.
+func NewWalkBox(id string, vertices []*Position) *WalkBox {
+	w := &WalkBox{
+		WalkBoxID: id,
+		Vertices:  vertices,
+		Enabled:   true,
+	}
+
+	if !w.isConvex() {
+		log.Panicf("walkbox must be a convex polygon: %v", vertices)
+	}
+	return w
+}
+
+// isConvex check if the current WalkBox is a convex poligon.
+func (w *WalkBox) isConvex() bool {
+	numVertices := len(w.Vertices)
+
+	if numVertices < MinPolygonVertices {
+		return false
+	}
+
+	var totalCrossProduct int
+	var polygonDirection bool // true if clockwise, false if counter-clockwise
+	for i := 0; i < numVertices; i++ {
+		// Get three consecutive vertices (cyclically)
+		p1 := w.Vertices[i]
+		p2 := w.Vertices[(i+1)%numVertices]
+		p3 := w.Vertices[(i+2)%numVertices]
+
+		cp := crossProduct(p1, p2, p3)
+
+		if cp == 0 {
+			continue // Skip collinear vertices
+		}
+
+		totalCrossProduct += cp
+
+		if i == 0 {
+			polygonDirection = cp > 0
+		} else {
+			if (cp > 0) != polygonDirection {
+				return false // If direction changes, the polygon is not convex
+			}
+		}
+	}
+	return totalCrossProduct != 0
+}
+
+// Enable sets the enabled state of the WalkBox.
+func (w *WalkBox) Enable(enable bool) *WalkBox {
+	w.Enabled = enable
+	return w
+}
+
+// ContainsPoint check if the provided position is in the boundaries defined by the WalkBox.
+func (w *WalkBox) ContainsPoint(p *Position) bool {
+	numberOfIntersections := 0
+	numVertices := len(w.Vertices)
+
+	for i := 0; i < numVertices; i++ {
+		p1 := w.Vertices[i]
+		p2 := w.Vertices[(i+1)%numVertices]
+
+		if isIntersecting(p, p1, p2) {
+			numberOfIntersections++
+		}
+	}
+
+	return numberOfIntersections%2 == 1 // Odd count means inside
+}
+
+// crossProduct calculates the cross product of the vectors formed by three consecutive vertices of a polygon.
+func crossProduct(p1, p2, p3 *Position) int {
+	return (p2.X-p1.X)*(p3.Y-p2.Y) - (p2.Y-p1.Y)*(p3.X-p2.X)
+}
+
+// isIntersecting calculate the x-coordinate of the intersection of the ray with the line segment (Ray-Casting method).
+func isIntersecting(p *Position, p1, p2 *Position) bool {
+	if (p1.Y > p.Y) != (p2.Y > p.Y) {
+		return p.X < (p2.X-p1.X)*(p.Y-p1.Y)/(p2.Y-p1.Y)+p1.X
+	}
+
+	return false
+}

--- a/walkbox_test.go
+++ b/walkbox_test.go
@@ -1,0 +1,165 @@
+package pctk_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/apoloval/pctk"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	DefaultWalkBoxID = "walkbox"
+)
+
+func TestNewWalkBox(t *testing.T) {
+	testCases := []struct {
+		name        string
+		vertices    []*pctk.Position
+		shouldPanic bool
+		message     string
+	}{
+		{
+			name:        "Insufficient vertices for a polygon",
+			vertices:    []*pctk.Position{{X: 0, Y: 0}, {X: 4, Y: 0}},
+			shouldPanic: true,
+			message:     fmt.Sprintf("Expected panic because we don't have enough vertices for a polygon (min required is %d)!", pctk.MinPolygonVertices),
+		},
+		{
+			name:        "Concave polygon should panic",
+			vertices:    []*pctk.Position{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 2, Y: 1}, {X: 4, Y: 4}},
+			shouldPanic: true,
+			message:     "Expected panic because vertices form a concave polygon!",
+		},
+		{
+			name:        "Collinear vertices should panic",
+			vertices:    []*pctk.Position{{X: 1, Y: 2}, {X: 2, Y: 4}, {X: 3, Y: 6}, {X: 4, Y: 8}},
+			shouldPanic: true,
+			message:     "Expected panic because vertices are collinear!",
+		},
+		{
+			name:        "Should successfully create a valid WalkBox with a convex polygon",
+			vertices:    []*pctk.Position{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 4}, {X: 0, Y: 4}},
+			shouldPanic: false,
+			message:     "Expected create a valid WalkBox, vertices form a convex polygon!",
+		},
+		{
+			name:        "Should successfully create a valid WalkBox with a complex convex polygon (octagon)",
+			vertices:    []*pctk.Position{{X: 0, Y: 0}, {X: 1, Y: 2}, {X: 2, Y: 3}, {X: 3, Y: 2}, {X: 4, Y: 0}, {X: 3, Y: -2}, {X: 2, Y: -3}, {X: 1, Y: -2}},
+			shouldPanic: false,
+			message:     "Expected create a valid WalkBox, vertices form a complex convex octagon!",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if testCase.shouldPanic {
+				assert.Panics(t, func() {
+					pctk.NewWalkBox(DefaultWalkBoxID, testCase.vertices)
+				}, testCase.message)
+			} else {
+				assert.NotPanics(t, func() {
+					pctk.NewWalkBox(DefaultWalkBoxID, testCase.vertices)
+				}, testCase.message)
+			}
+		})
+	}
+
+}
+
+func TestContainsPoint(t *testing.T) {
+	testCases := []struct {
+		name       string
+		vertices   []*pctk.Position
+		point      *pctk.Position
+		assertFunc func(t *testing.T, isInside bool)
+	}{
+		{
+			name:     "The point should be considered inside the polygon when it is on the edge",
+			vertices: []*pctk.Position{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 4}, {X: 0, Y: 4}},
+			point:    &pctk.Position{X: 2, Y: 0}, // On the edge
+			assertFunc: func(t *testing.T, isInside bool) {
+				assert.True(t, isInside)
+			},
+		},
+		{
+			name:     "The point should be inside the polygon",
+			vertices: []*pctk.Position{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 4}, {X: 0, Y: 4}},
+			point:    &pctk.Position{X: 2, Y: 2},
+			assertFunc: func(t *testing.T, isInside bool) {
+				assert.True(t, isInside)
+			},
+		},
+		{
+			name:     "The point should be outside the polygon",
+			vertices: []*pctk.Position{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 4}, {X: 0, Y: 4}},
+			point:    &pctk.Position{X: 5, Y: 5},
+			assertFunc: func(t *testing.T, isInside bool) {
+				assert.False(t, isInside)
+			},
+		},
+		{
+			name:     "The point should be considered inside the polygon when it is on a vertex",
+			vertices: []*pctk.Position{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 4}, {X: 0, Y: 4}},
+			point:    &pctk.Position{X: 0, Y: 0}, // On the vertex
+			assertFunc: func(t *testing.T, isInside bool) {
+				assert.True(t, isInside)
+			},
+		},
+		{
+			name:     "The point should be inside a complex convex polygon with more vertices",
+			vertices: []*pctk.Position{{X: 0, Y: 0}, {X: 5, Y: 0}, {X: 6, Y: 3}, {X: 4, Y: 6}, {X: 1, Y: 5}, {X: 0, Y: 2}},
+			point:    &pctk.Position{X: 3, Y: 3},
+			assertFunc: func(t *testing.T, isInside bool) {
+				assert.True(t, isInside)
+			},
+		},
+		{
+			name:     "The point should be outside when it is far from the polygon",
+			vertices: []*pctk.Position{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 4}, {X: 0, Y: 4}},
+			point:    &pctk.Position{X: 10, Y: 10}, // Clearly outside the polygon
+			assertFunc: func(t *testing.T, isInside bool) {
+				assert.False(t, isInside)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			walkBox := pctk.NewWalkBox(DefaultWalkBoxID, testCase.vertices)
+			isInside := walkBox.ContainsPoint(testCase.point)
+			testCase.assertFunc(t, isInside)
+		})
+	}
+}
+
+func TestEnable(t *testing.T) {
+	testCases := []struct {
+		name       string
+		enable     bool
+		assertFunc func(t *testing.T, walkBox *pctk.WalkBox)
+	}{
+		{
+			name:   "WalkBox.Enabled should set it to true",
+			enable: true,
+			assertFunc: func(t *testing.T, walkBox *pctk.WalkBox) {
+				assert.True(t, walkBox.Enabled, "Expected WalkBox to be enabled")
+			},
+		},
+		{
+			name:   "WalkBox.Enabled should set it to false (disabled)",
+			enable: false,
+			assertFunc: func(t *testing.T, walkBox *pctk.WalkBox) {
+				assert.False(t, walkBox.Enabled, "Expected WalkBox to be disabled")
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			vertices := []*pctk.Position{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 4}, {X: 0, Y: 4}}
+			walkBox := pctk.NewWalkBox(DefaultWalkBoxID, vertices)
+			walkBox.Enable(testCase.enable)
+			testCase.assertFunc(t, walkBox)
+		})
+	}
+}

--- a/walkbox_test.go
+++ b/walkbox_test.go
@@ -1,7 +1,6 @@
 package pctk_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/apoloval/pctk"
@@ -15,39 +14,27 @@ const (
 func TestNewWalkBox(t *testing.T) {
 	testCases := []struct {
 		name        string
-		vertices    []*pctk.Position
+		vertices    [4]*pctk.Positionf
 		shouldPanic bool
 		message     string
 	}{
 		{
-			name:        "Insufficient vertices for a polygon",
-			vertices:    []*pctk.Position{{X: 0, Y: 0}, {X: 4, Y: 0}},
-			shouldPanic: true,
-			message:     fmt.Sprintf("Expected panic because we don't have enough vertices for a polygon (min required is %d)!", pctk.MinPolygonVertices),
-		},
-		{
 			name:        "Concave polygon should panic",
-			vertices:    []*pctk.Position{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 2, Y: 1}, {X: 4, Y: 4}},
+			vertices:    [4]*pctk.Positionf{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 2, Y: 1}, {X: 4, Y: 4}},
 			shouldPanic: true,
 			message:     "Expected panic because vertices form a concave polygon!",
 		},
 		{
 			name:        "Collinear vertices should panic",
-			vertices:    []*pctk.Position{{X: 1, Y: 2}, {X: 2, Y: 4}, {X: 3, Y: 6}, {X: 4, Y: 8}},
+			vertices:    [4]*pctk.Positionf{{X: 1, Y: 2}, {X: 2, Y: 4}, {X: 3, Y: 6}, {X: 4, Y: 8}},
 			shouldPanic: true,
 			message:     "Expected panic because vertices are collinear!",
 		},
 		{
 			name:        "Should successfully create a valid WalkBox with a convex polygon",
-			vertices:    []*pctk.Position{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 4}, {X: 0, Y: 4}},
+			vertices:    [4]*pctk.Positionf{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 4}, {X: 0, Y: 4}},
 			shouldPanic: false,
 			message:     "Expected create a valid WalkBox, vertices form a convex polygon!",
-		},
-		{
-			name:        "Should successfully create a valid WalkBox with a complex convex polygon (octagon)",
-			vertices:    []*pctk.Position{{X: 0, Y: 0}, {X: 1, Y: 2}, {X: 2, Y: 3}, {X: 3, Y: 2}, {X: 4, Y: 0}, {X: 3, Y: -2}, {X: 2, Y: -3}, {X: 1, Y: -2}},
-			shouldPanic: false,
-			message:     "Expected create a valid WalkBox, vertices form a complex convex octagon!",
 		},
 	}
 
@@ -70,54 +57,46 @@ func TestNewWalkBox(t *testing.T) {
 func TestContainsPoint(t *testing.T) {
 	testCases := []struct {
 		name       string
-		vertices   []*pctk.Position
-		point      *pctk.Position
+		vertices   [4]*pctk.Positionf
+		point      *pctk.Positionf
 		assertFunc func(t *testing.T, isInside bool)
 	}{
 		{
 			name:     "The point should be considered inside the polygon when it is on the edge",
-			vertices: []*pctk.Position{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 4}, {X: 0, Y: 4}},
-			point:    &pctk.Position{X: 2, Y: 0}, // On the edge
+			vertices: [4]*pctk.Positionf{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 4}, {X: 0, Y: 4}},
+			point:    &pctk.Positionf{X: 2, Y: 0}, // On the edge
 			assertFunc: func(t *testing.T, isInside bool) {
 				assert.True(t, isInside)
 			},
 		},
 		{
 			name:     "The point should be inside the polygon",
-			vertices: []*pctk.Position{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 4}, {X: 0, Y: 4}},
-			point:    &pctk.Position{X: 2, Y: 2},
+			vertices: [4]*pctk.Positionf{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 4}, {X: 0, Y: 4}},
+			point:    &pctk.Positionf{X: 2, Y: 2},
 			assertFunc: func(t *testing.T, isInside bool) {
 				assert.True(t, isInside)
 			},
 		},
 		{
 			name:     "The point should be outside the polygon",
-			vertices: []*pctk.Position{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 4}, {X: 0, Y: 4}},
-			point:    &pctk.Position{X: 5, Y: 5},
+			vertices: [4]*pctk.Positionf{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 4}, {X: 0, Y: 4}},
+			point:    &pctk.Positionf{X: 5, Y: 5},
 			assertFunc: func(t *testing.T, isInside bool) {
 				assert.False(t, isInside)
 			},
 		},
 		{
 			name:     "The point should be considered inside the polygon when it is on a vertex",
-			vertices: []*pctk.Position{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 4}, {X: 0, Y: 4}},
-			point:    &pctk.Position{X: 0, Y: 0}, // On the vertex
-			assertFunc: func(t *testing.T, isInside bool) {
-				assert.True(t, isInside)
-			},
-		},
-		{
-			name:     "The point should be inside a complex convex polygon with more vertices",
-			vertices: []*pctk.Position{{X: 0, Y: 0}, {X: 5, Y: 0}, {X: 6, Y: 3}, {X: 4, Y: 6}, {X: 1, Y: 5}, {X: 0, Y: 2}},
-			point:    &pctk.Position{X: 3, Y: 3},
+			vertices: [4]*pctk.Positionf{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 4}, {X: 0, Y: 4}},
+			point:    &pctk.Positionf{X: 0, Y: 0}, // On the vertex
 			assertFunc: func(t *testing.T, isInside bool) {
 				assert.True(t, isInside)
 			},
 		},
 		{
 			name:     "The point should be outside when it is far from the polygon",
-			vertices: []*pctk.Position{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 4}, {X: 0, Y: 4}},
-			point:    &pctk.Position{X: 10, Y: 10}, // Clearly outside the polygon
+			vertices: [4]*pctk.Positionf{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 4}, {X: 0, Y: 4}},
+			point:    &pctk.Positionf{X: 10, Y: 10}, // Clearly outside the polygon
 			assertFunc: func(t *testing.T, isInside bool) {
 				assert.False(t, isInside)
 			},
@@ -128,38 +107,6 @@ func TestContainsPoint(t *testing.T) {
 			walkBox := pctk.NewWalkBox(DefaultWalkBoxID, testCase.vertices)
 			isInside := walkBox.ContainsPoint(testCase.point)
 			testCase.assertFunc(t, isInside)
-		})
-	}
-}
-
-func TestEnable(t *testing.T) {
-	testCases := []struct {
-		name       string
-		enable     bool
-		assertFunc func(t *testing.T, walkBox *pctk.WalkBox)
-	}{
-		{
-			name:   "WalkBox.Enabled should set it to true",
-			enable: true,
-			assertFunc: func(t *testing.T, walkBox *pctk.WalkBox) {
-				assert.True(t, walkBox.Enabled, "Expected WalkBox to be enabled")
-			},
-		},
-		{
-			name:   "WalkBox.Enabled should set it to false (disabled)",
-			enable: false,
-			assertFunc: func(t *testing.T, walkBox *pctk.WalkBox) {
-				assert.False(t, walkBox.Enabled, "Expected WalkBox to be disabled")
-			},
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			vertices := []*pctk.Position{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 4}, {X: 0, Y: 4}}
-			walkBox := pctk.NewWalkBox(DefaultWalkBoxID, vertices)
-			walkBox.Enable(testCase.enable)
-			testCase.assertFunc(t, walkBox)
 		})
 	}
 }


### PR DESCRIPTION
Minimal `WalkBox` support.

This MR covers the point 1 described in https://github.com/apoloval/pctk/issues/19

```
1. WalkBox minimal definition:
  - WalkBox creation: Must be a valid convex polygon.
  - ContainsPoint function to check if a point is inside the WalkBox,
  - Enable function to enable or disable the WalkBox

```  
