### PR TITLE
WalkBoxMatrix part 1

### DIFF
--- a/space.go
+++ b/space.go
@@ -182,6 +182,11 @@ func (p *Positionf) IsIntersecting(p1, p2 *Positionf) bool {
 	return false
 }
 
+// Equals returns true if both Positionf instances have the same X and Y coordinates.
+func (p *Positionf) Equals(p1 *Positionf) bool {
+	return p.X == p1.X && p.Y == p1.Y
+}
+
 // Size represents a 2D size.
 type Size struct {
 	W, H int

--- a/walkbox.go
+++ b/walkbox.go
@@ -187,13 +187,13 @@ func (wm *WalkBoxMatrix) walkBoxAt(p *Positionf) (id int, included bool) {
 	panic("Not implemented yet!")
 }
 
-// ClosestPositionToWalkBox returns the closest point to the specified walkbox identifiers from
+// closestPositionToWalkBox returns the closest point to the specified walkbox identifiers from
 // the origin.
-func (wm *WalkBoxMatrix) cllosestPositionToWalkBox(from, to int) *Positionf {
+func (wm *WalkBoxMatrix) closestPositionToWalkBox(from, to int) *Positionf {
 	panic("Not implemented yet!")
 }
 
-// ClosestPositionOnWalkBox returns the closest point on the walk box at a given position.
+// closestPositionOnWalkBox returns the closest point on the walk box at a given position.
 func (wm *WalkBoxMatrix) closestPositionOnWalkBox(p *Positionf) *Positionf {
 	panic("Not implemented yet!")
 }

--- a/walkbox.go
+++ b/walkbox.go
@@ -172,3 +172,20 @@ func (wm *WalkBoxMatrix) EnableWalkBox(id int, enabled bool) {
 		wm.itineraryMatrix = calculateItineraryMatrix(wm.walkBoxes)
 	}
 }
+
+// WalkBoxAt returns the walk box identifier at the given position or the closest one,
+// along with a boolean indicating inclusion.
+func (wm *WalkBoxMatrix) WalkBoxAt(p *Positionf) (id int, included bool) {
+	panic("Not implemented yet!")
+}
+
+// ClosestPositionToWalkBox returns the closest point to the specified walkbox identifiers from
+// the origin.
+func (wm *WalkBoxMatrix) ClosestPositionToWalkBox(from, to int) *Positionf {
+	panic("Not implemented yet!")
+}
+
+// ClosestPositionOnWalkBox returns the closest point on the walk box at a given position.
+func (wm *WalkBoxMatrix) ClosestPositionOnWalkBox(p *Positionf) *Positionf {
+	panic("Not implemented yet!")
+}

--- a/walkbox.go
+++ b/walkbox.go
@@ -158,14 +158,6 @@ func calculateItineraryMatrix(walkboxes []*WalkBox) [][]int {
 	return itineraryMatrix
 }
 
-// NextWalkBox returns the next walk box in the path from the source to the destination.
-func (wm *WalkBoxMatrix) NextWalkBox(from, to int) int {
-	if from < 0 || from >= len(wm.walkBoxes) || to < 0 || to >= len(wm.walkBoxes) {
-		return InvalidWalkBox
-	}
-	return wm.itineraryMatrix[from][to]
-}
-
 // EnableWalkBox enables or disables the specified walk box and recalculates the itinerary matrix.
 func (wm *WalkBoxMatrix) EnableWalkBox(id int, enabled bool) {
 	if id >= 0 && id < len(wm.walkBoxes) {
@@ -174,19 +166,34 @@ func (wm *WalkBoxMatrix) EnableWalkBox(id int, enabled bool) {
 	}
 }
 
-// WalkBoxAt returns the walk box identifier at the given position or the closest one,
+// FindPath calculates and returns a path as a sequence of positions from the
+// starting point 'from' to the destination 'to' within the walk box matrix.
+// The path is returned as a slice of positions representing waypoints.
+func (wm *WalkBoxMatrix) FindPath(from, to *Positionf) []*Positionf {
+	panic("Not implemented yet!")
+}
+
+// nextWalkBox returns the next walk box in the path from the source to the destination.
+func (wm *WalkBoxMatrix) nextWalkBox(from, to int) int {
+	if from < 0 || from >= len(wm.walkBoxes) || to < 0 || to >= len(wm.walkBoxes) {
+		return InvalidWalkBox
+	}
+	return wm.itineraryMatrix[from][to]
+}
+
+// walkBoxAt returns the walk box identifier at the given position or the closest one,
 // along with a boolean indicating inclusion.
-func (wm *WalkBoxMatrix) WalkBoxAt(p *Positionf) (id int, included bool) {
+func (wm *WalkBoxMatrix) walkBoxAt(p *Positionf) (id int, included bool) {
 	panic("Not implemented yet!")
 }
 
 // ClosestPositionToWalkBox returns the closest point to the specified walkbox identifiers from
 // the origin.
-func (wm *WalkBoxMatrix) ClosestPositionToWalkBox(from, to int) *Positionf {
+func (wm *WalkBoxMatrix) cllosestPositionToWalkBox(from, to int) *Positionf {
 	panic("Not implemented yet!")
 }
 
 // ClosestPositionOnWalkBox returns the closest point on the walk box at a given position.
-func (wm *WalkBoxMatrix) ClosestPositionOnWalkBox(p *Positionf) *Positionf {
+func (wm *WalkBoxMatrix) closestPositionOnWalkBox(p *Positionf) *Positionf {
 	panic("Not implemented yet!")
 }

--- a/walkbox.go
+++ b/walkbox.go
@@ -88,6 +88,13 @@ func (w *WalkBox) IsAdjacent(otherWalkBox *WalkBox) bool {
 				return true
 			}
 		}
+
+		// two-way verification
+		for _, vertex := range w.vertices {
+			if otherWalkBox.ContainsPoint(vertex) {
+				return true
+			}
+		}
 	}
 
 	return false

--- a/walkbox.go
+++ b/walkbox.go
@@ -1,8 +1,6 @@
 package pctk
 
-import (
-	"log"
-)
+import "log"
 
 // Walkbox refers to a convex polygonal area that defines the walkable space for actors.
 type WalkBox struct {

--- a/walkbox.go
+++ b/walkbox.go
@@ -116,12 +116,13 @@ func NewWalkBoxMatrix(walkboxes []*WalkBox) *WalkBoxMatrix {
 
 // calculateItineraryMatrix computes the shortest paths between WalkBoxes and returns the resulting itinerary matrix.
 func calculateItineraryMatrix(walkboxes []*WalkBox) [][]int {
-	distanceMatrix := make([][]int, len(walkboxes))
-	itineraryMatrix := make([][]int, len(walkboxes))
+	numBoxes := len(walkboxes)
+	distanceMatrix := make([][]int, numBoxes)
+	itineraryMatrix := make([][]int, numBoxes)
 
 	for i, walkbox := range walkboxes {
-		itineraryMatrix[i] = make([]int, len(walkboxes))
-		distanceMatrix[i] = make([]int, len(walkboxes))
+		itineraryMatrix[i] = make([]int, numBoxes)
+		distanceMatrix[i] = make([]int, numBoxes)
 
 		// Initialize the distance matrix: each box has distance 0 to itself,
 		// and distance 1 to its direct neighbors. Initially, it has distance

--- a/walkbox.go
+++ b/walkbox.go
@@ -115,26 +115,28 @@ const (
 
 // NewWalkBoxMatrix creates and returns a new WalkBoxMatrix instance
 func NewWalkBoxMatrix(walkboxes []*WalkBox) *WalkBoxMatrix {
-	return &WalkBoxMatrix{
-		walkBoxes:       walkboxes,
-		itineraryMatrix: calculateItineraryMatrix(walkboxes),
+	wm := &WalkBoxMatrix{
+		walkBoxes: walkboxes,
 	}
+
+	wm.resetItinerary()
+	return wm
 }
 
 // calculateItineraryMatrix computes the shortest paths between WalkBoxes and returns the resulting itinerary matrix.
-func calculateItineraryMatrix(walkboxes []*WalkBox) [][]int {
-	numBoxes := len(walkboxes)
+func (wm *WalkBoxMatrix) resetItinerary() {
+	numBoxes := len(wm.walkBoxes)
 	distanceMatrix := make([][]int, numBoxes)
 	itineraryMatrix := make([][]int, numBoxes)
 
-	for i, walkbox := range walkboxes {
+	for i, walkbox := range wm.walkBoxes {
 		itineraryMatrix[i] = make([]int, numBoxes)
 		distanceMatrix[i] = make([]int, numBoxes)
 
 		// Initialize the distance matrix: each box has distance 0 to itself,
 		// and distance 1 to its direct neighbors. Initially, it has distance
 		// 255 (= infinityDistance) to all other boxes.
-		for j, otherWalkBox := range walkboxes {
+		for j, otherWalkBox := range wm.walkBoxes {
 			if i == j {
 				distanceMatrix[i][j] = 0
 				itineraryMatrix[i][j] = i
@@ -149,9 +151,9 @@ func calculateItineraryMatrix(walkboxes []*WalkBox) [][]int {
 	}
 
 	// Compute the shortest routes between boxes via Kleene's algorithm.
-	for i := range walkboxes {
-		for j := range walkboxes {
-			for k := range walkboxes {
+	for i := range wm.walkBoxes {
+		for j := range wm.walkBoxes {
+			for k := range wm.walkBoxes {
 				distIK := distanceMatrix[i][k]
 				distKJ := distanceMatrix[k][j]
 				if distanceMatrix[i][j] > distIK+distKJ {
@@ -162,14 +164,14 @@ func calculateItineraryMatrix(walkboxes []*WalkBox) [][]int {
 		}
 	}
 
-	return itineraryMatrix
+	wm.itineraryMatrix = itineraryMatrix
 }
 
 // EnableWalkBox enables or disables the specified walk box and recalculates the itinerary matrix.
 func (wm *WalkBoxMatrix) EnableWalkBox(id int, enabled bool) {
 	if id >= 0 && id < len(wm.walkBoxes) {
 		wm.walkBoxes[id].enabled = enabled
-		wm.itineraryMatrix = calculateItineraryMatrix(wm.walkBoxes)
+		wm.resetItinerary()
 	}
 }
 

--- a/walkbox_test.go
+++ b/walkbox_test.go
@@ -115,8 +115,8 @@ func TestWalkBoxIsAdjacent(t *testing.T) {
 	/*
 		Polygons disposition:
 
-			      +-------+
-			      |       |
+		          +-------+
+		          |       |
 		  +-------|       |
 		  |       |       |
 		  | box6  | box7  |

--- a/walkbox_test.go
+++ b/walkbox_test.go
@@ -113,25 +113,39 @@ func TestContainsPoint(t *testing.T) {
 
 func TestWalkBoxIsAdjacent(t *testing.T) {
 	/*
-		Polygons disposition:
+				Polygons disposition:
 
-		  +-------+-------+-------+
-		  |       |       |       |
-		  | box3  | box4  | box5  |
-		  |       |       |       |
-		  +-------+-------+-------+
-		  |       |       |       |
-		  | box0  | box1  | box2  |
-		  |       |       |       |
-		  +-------+-------+-------+
+						  +-------+
+		                  |       |
+						  |       |
+					      |       |
+				  +-------+       |
+				  |       |       |
+				  | box6  | box7  |
+				  |       |       |
+				  +-------+       |
+				  		  |       |
+				          |       |
+				          |       |
+				  +-------+-------+-------+
+				  |       |       |       |
+				  | box3  | box4  | box5  |
+				  |       |       |       |
+				  +-------+-------+-------+
+				  |       |       |       |
+				  | box0  | box1  | box2  |
+				  |       |       |       |
+				  +-------+-------+-------+
 
-		Each box represents a square, with adjacent connections:
-		- box0 is adjacent to box1, box3
-		- box1 is adjacent to box0, box2, box3, box4
-		- box2 is adjacent to box1, box4, box5
-		- box3 is adjacent to box0, box1, box4
-		- box4 is adjacent to box1, box2, box3, box5
-		- box5 is adjacent to box2, box4
+				Each box represents a square, with adjacent connections:
+				- box0 is adjacent to box1, box3, box4
+				- box1 is adjacent to box0, box2, box3, box4, box5
+				- box2 is adjacent to box1, box4, box5
+				- box3 is adjacent to box0, box1, box4, box7
+				- box4 is adjacent to box0, box1, box2, box3, box5, box7
+				- box5 is adjacent to box1, box2, box4, box7
+				- box6 is adjacent to box7
+				- box7 is adjacent to box4, box5
 	*/
 
 	box0 := pctk.NewWalkBox("walkbox0", [4]*pctk.Positionf{{0, 0}, {1, 0}, {1, 1}, {0, 1}})
@@ -140,20 +154,32 @@ func TestWalkBoxIsAdjacent(t *testing.T) {
 	box3 := pctk.NewWalkBox("walkbox3", [4]*pctk.Positionf{{0, 1}, {1, 1}, {1, 2}, {0, 2}})
 	box4 := pctk.NewWalkBox("walkbox4", [4]*pctk.Positionf{{1, 1}, {2, 1}, {2, 2}, {1, 2}})
 	box5 := pctk.NewWalkBox("walkbox5", [4]*pctk.Positionf{{2, 1}, {3, 1}, {3, 2}, {2, 2}})
+	box6 := pctk.NewWalkBox("walkbox6", [4]*pctk.Positionf{{0, 3}, {1, 3}, {1, 4}, {0, 4}})
+	box7 := pctk.NewWalkBox("walkbox7", [4]*pctk.Positionf{{1, 2}, {2, 2}, {2, 5}, {1, 5}})
 
 	assert.True(t, box0.IsAdjacent(box1), "box0 should be adjacent to box1")
-	assert.True(t, box1.IsAdjacent(box2), "box1 should be adjacent to box2")
-	assert.True(t, box1.IsAdjacent(box3), "box1 should be adjacent to box3")
 	assert.True(t, box0.IsAdjacent(box3), "box0 should be adjacent to box3")
 	assert.True(t, box0.IsAdjacent(box4), "box0 should be adjacent to box4")
+	assert.True(t, box1.IsAdjacent(box0), "box1 should be adjacent to box0")
+	assert.True(t, box1.IsAdjacent(box2), "box1 should be adjacent to box2")
+	assert.True(t, box1.IsAdjacent(box3), "box1 should be adjacent to box3")
 	assert.True(t, box1.IsAdjacent(box4), "box1 should be adjacent to box4")
-	assert.True(t, box3.IsAdjacent(box4), "box3 should be adjacent to box4")
 	assert.True(t, box2.IsAdjacent(box4), "box2 should be adjacent to box4")
 	assert.True(t, box2.IsAdjacent(box5), "box2 should be adjacent to box5")
+	assert.True(t, box3.IsAdjacent(box0), "box3 should be adjacent to box0")
+	assert.True(t, box3.IsAdjacent(box1), "box3 should be adjacent to box1")
+	assert.True(t, box3.IsAdjacent(box4), "box3 should be adjacent to box4")
+	assert.True(t, box3.IsAdjacent(box7), "box3 should be adjacent to box7")
 	assert.True(t, box4.IsAdjacent(box5), "box4 should be adjacent to box5")
+	assert.True(t, box4.IsAdjacent(box7), "box4 should be adjacent to box7")
+	assert.True(t, box5.IsAdjacent(box7), "box5 should be adjacent to box7")
 	// Test non-adjacency
 	assert.False(t, box0.IsAdjacent(box2), "box0 should not be adjacent to box2")
 	assert.False(t, box3.IsAdjacent(box2), "box3 should not be adjacent to box2")
 	assert.False(t, box0.IsAdjacent(box5), "box0 should not be adjacent to box5")
+	assert.False(t, box6.IsAdjacent(box3), "box6 should not be adjacent to box3")
+	// Test adjacency when there are no shared vertices and no overlapping areas
+	assert.True(t, box6.IsAdjacent(box7), "box6 should be adjacent to box7")
+	assert.True(t, box7.IsAdjacent(box6), "box7 should be adjacent to box6")
 
 }

--- a/walkbox_test.go
+++ b/walkbox_test.go
@@ -111,7 +111,7 @@ func TestContainsPoint(t *testing.T) {
 	}
 }
 
-func TestWalkBoxMatrix(t *testing.T) {
+func TestWalkBoxIsAdjacent(t *testing.T) {
 	/*
 		Polygons disposition:
 
@@ -141,8 +141,6 @@ func TestWalkBoxMatrix(t *testing.T) {
 	box4 := pctk.NewWalkBox("walkbox4", [4]*pctk.Positionf{{1, 1}, {2, 1}, {2, 2}, {1, 2}})
 	box5 := pctk.NewWalkBox("walkbox5", [4]*pctk.Positionf{{2, 1}, {3, 1}, {3, 2}, {2, 2}})
 
-	wm := pctk.NewWalkBoxMatrix([]*pctk.WalkBox{box0, box1, box2, box3, box4, box5})
-
 	assert.True(t, box0.IsAdjacent(box1), "box0 should be adjacent to box1")
 	assert.True(t, box1.IsAdjacent(box2), "box1 should be adjacent to box2")
 	assert.True(t, box1.IsAdjacent(box3), "box1 should be adjacent to box3")
@@ -158,30 +156,4 @@ func TestWalkBoxMatrix(t *testing.T) {
 	assert.False(t, box3.IsAdjacent(box2), "box3 should not be adjacent to box2")
 	assert.False(t, box0.IsAdjacent(box5), "box0 should not be adjacent to box5")
 
-	// Test pathfinding from box0 to box2 via box1
-	from := 0
-	to := 2
-	next := wm.NextWalkBox(from, to)
-	assert.Equal(t, 1, next, "Next walk box from 0 to 2 should be 1")
-
-	next = wm.NextWalkBox(next, to)
-	assert.Equal(t, to, next, "Next walk box from 1 to 2 should be 2")
-
-	// Disable box1 and test new path from box0 to box2
-	wm.EnableWalkBox(1, false)
-	next = wm.NextWalkBox(from, to)
-	assert.Equal(t, 4, next, "Next walk box from 0 to 2 with box1 disabled should be 4")
-
-	next = wm.NextWalkBox(next, to)
-	assert.Equal(t, to, next, "Next walk box from 4 to 2 should be 2")
-
-	// Test path when destination (box1) is disabled
-	to = 1
-	next = wm.NextWalkBox(from, to)
-	assert.Equal(t, pctk.InvalidWalkBox, next, "Next walk box from 0 to 1 should be invalid since box1 is disabled")
-
-	// Re-enable box1 and test path again
-	wm.EnableWalkBox(1, true)
-	next = wm.NextWalkBox(from, to)
-	assert.Equal(t, to, next, "Next walk box from 0 to 1 should be 1 after re-enabling box1")
 }

--- a/walkbox_test.go
+++ b/walkbox_test.go
@@ -113,39 +113,35 @@ func TestContainsPoint(t *testing.T) {
 
 func TestWalkBoxIsAdjacent(t *testing.T) {
 	/*
-				Polygons disposition:
+		Polygons disposition:
 
-						  +-------+
-		                  |       |
-						  |       |
-					      |       |
-				  +-------+       |
-				  |       |       |
-				  | box6  | box7  |
-				  |       |       |
-				  +-------+       |
-				  		  |       |
-				          |       |
-				          |       |
-				  +-------+-------+-------+
-				  |       |       |       |
-				  | box3  | box4  | box5  |
-				  |       |       |       |
-				  +-------+-------+-------+
-				  |       |       |       |
-				  | box0  | box1  | box2  |
-				  |       |       |       |
-				  +-------+-------+-------+
+			      +-------+
+			      |       |
+		  +-------|       |
+		  |       |       |
+		  | box6  | box7  |
+		  |       |       |
+		  +-------|       |
+		          |       |
+		  +-------+-------+-------+
+		  |       |       |       |
+		  | box3  | box4  | box5  |
+		  |       |       |       |
+		  +-------+-------+-------+
+		  |       |       |       |
+		  | box0  | box1  | box2  |
+		  |       |       |       |
+		  +-------+-------+-------+
 
-				Each box represents a square, with adjacent connections:
-				- box0 is adjacent to box1, box3, box4
-				- box1 is adjacent to box0, box2, box3, box4, box5
-				- box2 is adjacent to box1, box4, box5
-				- box3 is adjacent to box0, box1, box4, box7
-				- box4 is adjacent to box0, box1, box2, box3, box5, box7
-				- box5 is adjacent to box1, box2, box4, box7
-				- box6 is adjacent to box7
-				- box7 is adjacent to box4, box5
+		Each box represents a square, except box7, which is three times taller.
+		- box0 is adjacent to box1, box3
+		- box1 is adjacent to box0, box2, box3, box4
+		- box2 is adjacent to box1, box5
+		- box3 is adjacent to box0, box1, box4
+		- box4 is adjacent to box1, box3, box5, box7
+		- box5 is adjacent to box2, box4
+		- box6 is adjacent to box7 (positioned above box3 but not connected)
+		- box7 is adjacent to box4, box6 (taller and positioned above box4)
 	*/
 
 	box0 := pctk.NewWalkBox("walkbox0", [4]*pctk.Positionf{{0, 0}, {1, 0}, {1, 1}, {0, 1}})


### PR DESCRIPTION
Related to https://github.com/apoloval/pctk/issues/19 (point 2)

A few considerations / notes for the revision

- Not implementad as a pure graph, I mean, no Edge / Vertex structs are defined cause we no need it to calculate shortest path, or other functions required for the matrix. We can reduce this complexity (or add it in the future if it is needed)
- We need to check a Matrix is valid and  fail fast during packing. I used the approach during `Add` operation. The side effect is, the definition of walkboxes must be in order (scripts). Not sure if we want that. We can use another approach allowing create the Matrix accepting an array of walkboxes, and internally in the creation, check if is valid. 
- Not sure if we need `Adjacents` function,  but I defined for testing purposes (to validate that the internal adjacency list  is created properly). No strong opinion to remove it (and the test related) and add it in the future if it is needed.


