### PR TITLE
Proposed WalkBoxMatrix API

### DIFF
--- a/walkbox.go
+++ b/walkbox.go
@@ -172,3 +172,20 @@ func (wm *WalkBoxMatrix) EnableWalkBox(id int, enabled bool) {
 		wm.itineraryMatrix = calculateItineraryMatrix(wm.walkBoxes)
 	}
 }
+
+// WalkBoxAt returns the walk box identifier at the given position or the closest one,
+// along with a boolean indicating inclusion.
+func (wm *WalkBoxMatrix) WalkBoxAt(p *Positionf) (id int, included bool) {
+	panic("Not implemented yet!")
+}
+
+// ClosestPositionToWalkBox returns the closest point to the specified walkbox identifiers from
+// the origin.
+func (wm *WalkBoxMatrix) ClosestPositionToWalkBox(from, to int) *Positionf {
+	panic("Not implemented yet!")
+}
+
+// ClosestPositionOnWalkBox returns the closest point on the walk box at a given position.
+func (wm *WalkBoxMatrix) ClosestPositionOnWalkBox(p *Positionf) *Positionf {
+	panic("Not implemented yet!")
+}

--- a/walkbox.go
+++ b/walkbox.go
@@ -158,14 +158,6 @@ func calculateItineraryMatrix(walkboxes []*WalkBox) [][]int {
 	return itineraryMatrix
 }
 
-// NextWalkBox returns the next walk box in the path from the source to the destination.
-func (wm *WalkBoxMatrix) NextWalkBox(from, to int) int {
-	if from < 0 || from >= len(wm.walkBoxes) || to < 0 || to >= len(wm.walkBoxes) {
-		return InvalidWalkBox
-	}
-	return wm.itineraryMatrix[from][to]
-}
-
 // EnableWalkBox enables or disables the specified walk box and recalculates the itinerary matrix.
 func (wm *WalkBoxMatrix) EnableWalkBox(id int, enabled bool) {
 	if id >= 0 && id < len(wm.walkBoxes) {
@@ -174,19 +166,34 @@ func (wm *WalkBoxMatrix) EnableWalkBox(id int, enabled bool) {
 	}
 }
 
-// WalkBoxAt returns the walk box identifier at the given position or the closest one,
+// FindPath calculates and returns a path as a sequence of positions from the
+// starting point 'from' to the destination 'to' within the walk box matrix.
+// The path is returned as a slice of positions representing waypoints.
+func (wm *WalkBoxMatrix) FindPath(from, to *Positionf) []*Positionf {
+	panic("Not implemented yet!")
+}
+
+// nextWalkBox returns the next walk box in the path from the source to the destination.
+func (wm *WalkBoxMatrix) nextWalkBox(from, to int) int {
+	if from < 0 || from >= len(wm.walkBoxes) || to < 0 || to >= len(wm.walkBoxes) {
+		return InvalidWalkBox
+	}
+	return wm.itineraryMatrix[from][to]
+}
+
+// walkBoxAt returns the walk box identifier at the given position or the closest one,
 // along with a boolean indicating inclusion.
-func (wm *WalkBoxMatrix) WalkBoxAt(p *Positionf) (id int, included bool) {
+func (wm *WalkBoxMatrix) walkBoxAt(p *Positionf) (id int, included bool) {
 	panic("Not implemented yet!")
 }
 
 // ClosestPositionToWalkBox returns the closest point to the specified walkbox identifiers from
 // the origin.
-func (wm *WalkBoxMatrix) ClosestPositionToWalkBox(from, to int) *Positionf {
+func (wm *WalkBoxMatrix) cllosestPositionToWalkBox(from, to int) *Positionf {
 	panic("Not implemented yet!")
 }
 
 // ClosestPositionOnWalkBox returns the closest point on the walk box at a given position.
-func (wm *WalkBoxMatrix) ClosestPositionOnWalkBox(p *Positionf) *Positionf {
+func (wm *WalkBoxMatrix) closestPositionOnWalkBox(p *Positionf) *Positionf {
 	panic("Not implemented yet!")
 }

--- a/walkbox_test.go
+++ b/walkbox_test.go
@@ -111,7 +111,7 @@ func TestContainsPoint(t *testing.T) {
 	}
 }
 
-func TestWalkBoxMatrix(t *testing.T) {
+func TestWalkBoxIsAdjacent(t *testing.T) {
 	/*
 		Polygons disposition:
 
@@ -141,8 +141,6 @@ func TestWalkBoxMatrix(t *testing.T) {
 	box4 := pctk.NewWalkBox("walkbox4", [4]*pctk.Positionf{{1, 1}, {2, 1}, {2, 2}, {1, 2}})
 	box5 := pctk.NewWalkBox("walkbox5", [4]*pctk.Positionf{{2, 1}, {3, 1}, {3, 2}, {2, 2}})
 
-	wm := pctk.NewWalkBoxMatrix([]*pctk.WalkBox{box0, box1, box2, box3, box4, box5})
-
 	assert.True(t, box0.IsAdjacent(box1), "box0 should be adjacent to box1")
 	assert.True(t, box1.IsAdjacent(box2), "box1 should be adjacent to box2")
 	assert.True(t, box1.IsAdjacent(box3), "box1 should be adjacent to box3")
@@ -158,30 +156,4 @@ func TestWalkBoxMatrix(t *testing.T) {
 	assert.False(t, box3.IsAdjacent(box2), "box3 should not be adjacent to box2")
 	assert.False(t, box0.IsAdjacent(box5), "box0 should not be adjacent to box5")
 
-	// Test pathfinding from box0 to box2 via box1
-	from := 0
-	to := 2
-	next := wm.NextWalkBox(from, to)
-	assert.Equal(t, 1, next, "Next walk box from 0 to 2 should be 1")
-
-	next = wm.NextWalkBox(next, to)
-	assert.Equal(t, to, next, "Next walk box from 1 to 2 should be 2")
-
-	// Disable box1 and test new path from box0 to box2
-	wm.EnableWalkBox(1, false)
-	next = wm.NextWalkBox(from, to)
-	assert.Equal(t, 4, next, "Next walk box from 0 to 2 with box1 disabled should be 4")
-
-	next = wm.NextWalkBox(next, to)
-	assert.Equal(t, to, next, "Next walk box from 4 to 2 should be 2")
-
-	// Test path when destination (box1) is disabled
-	to = 1
-	next = wm.NextWalkBox(from, to)
-	assert.Equal(t, pctk.InvalidWalkBox, next, "Next walk box from 0 to 1 should be invalid since box1 is disabled")
-
-	// Re-enable box1 and test path again
-	wm.EnableWalkBox(1, true)
-	next = wm.NextWalkBox(from, to)
-	assert.Equal(t, to, next, "Next walk box from 0 to 1 should be 1 after re-enabling box1")
 }


### PR DESCRIPTION
Related to https://github.com/apoloval/pctk/issues/19 point 2

Here is the rest of the functions to support actor paths calculation in higher layers (room for example):

- ClosesPositionToWalkBox allow us get the position that connects two walboxes (like gates)
- WalkBoxAt get the current or closest walkbox also indicating if the poing is inside the box
- ClosesPointOnWalkBox to obtain the closes position to p for the current walkbox

Room's FindPath pseudocode would be:

```go
// p represents where the player clicked returning the line (bunch of points)
// to move the actor from its position to p
function (r *Room) FindPath(a *Actor, p *Positionf) [] *Positionf{
  var path []*Positionf
  current,_ := r.wbmatrix.WalkBoxAt(a.pos)
  target, _:= r.wbmatrix.WalkBoxAt(p)
  
  for current != target{
    next = r.wbmatrix.Next(current, target)
    if next == InvalidNode {
      break
    }
    path = append(path, r.wbmatrix.ClosesPositionToWalkBox(current, next)
    current = next
  }
  path = append(path, r.wbmatrix.ClosesPositionOnWalkBox(current, p)
  return path
}
```

Use this array of positions to move the actor


<img width="661" alt="image" src="https://github.com/user-attachments/assets/bd8d2554-6a02-4a33-ba99-7553d6135249">


With this approach, no need `Gates`  (https://github.com/scummvm/scummvm/blob/master/engines/scumm/boxes.cpp#L1292)