### PR TITLE
Fix talking issues

### DIFF
--- a/actor.go
+++ b/actor.go
@@ -28,6 +28,7 @@ type Actor struct {
 
 	act       *Action
 	costume   *Costume
+	dialog    *Dialog
 	elev      int
 	ego       bool
 	id        string
@@ -114,6 +115,11 @@ func (a *Actor) IsEgo() bool {
 	return a.ego
 }
 
+// IsSpeaking returns true if the actor is speaking, false otherwise.
+func (a *Actor) IsSpeaking() bool {
+	return a.dialog != nil && !a.dialog.Done().IsCompleted()
+}
+
 // Locate the actor in the given room, position and direction.
 func (a *Actor) Locate(room *Room, pos Position, dir Direction) {
 	a.room = room
@@ -148,6 +154,11 @@ func (a *Actor) SetCostume(costume *Costume) *Actor {
 	return a
 }
 
+// SetCurrentDialog sets the current dialog for the actor.
+func (a *Actor) SetCurrentDialog(dialog *Dialog) {
+	a.dialog = dialog
+}
+
 // ScriptLocation returns the location of the actor in the script.
 func (a *Actor) ScriptLocation() FieldAccessor {
 	return a.scriptLoc
@@ -178,8 +189,12 @@ func Standing(dir Direction) *Action {
 		prom: NewPromise(),
 		f: func(a *Actor, done *Promise) {
 			a.lookAt = dir
+			costume := CostumeIdle(dir)
+			if a.IsSpeaking() {
+				costume = CostumeSpeak(dir)
+			}
 			if cos := a.costume; cos != nil {
-				cos.draw(CostumeIdle(dir), a.costumePos())
+				cos.draw(costume, a.costumePos())
 			}
 		},
 	}

--- a/command_actor.go
+++ b/command_actor.go
@@ -251,6 +251,7 @@ func (cmd ActorSpeak) Execute(app *App, done *Promise) {
 	}
 
 	dialogDone := app.RunCommand(ShowDialog{
+		Actor:    cmd.Actor,
 		Text:     cmd.Text,
 		Position: cmd.Actor.dialogPos(),
 		Color:    cmd.Color,

--- a/command_dialog.go
+++ b/command_dialog.go
@@ -4,6 +4,7 @@ import "time"
 
 // ShowDialog is a command that will show a dialog with the given text.
 type ShowDialog struct {
+	Actor    *Actor
 	Text     string
 	Position Position
 	Color    Color
@@ -22,13 +23,18 @@ func (cmd ShowDialog) Execute(app *App, done *Promise) {
 	shownDuring /= time.Duration(cmd.Speed)
 	expiresAt := time.Now().Add(shownDuring)
 
+	if cmd.Actor != nil {
+		app.ClearDialogsFrom(cmd.Actor)
+	}
+
 	dialog := Dialog{
-		text:      cmd.Text,
-		pos:       cmd.Position,
-		color:     cmd.Color,
-		speed:     cmd.Speed,
-		expiresAt: expiresAt,
-		done:      done,
+		actor:       cmd.Actor,
+		text:        cmd.Text,
+		pos:         cmd.Position,
+		color:       cmd.Color,
+		speed:       cmd.Speed,
+		completedAt: expiresAt,
+		done:        done,
 	}
 	app.dialogs = append(app.dialogs, dialog)
 }

--- a/command_dialog.go
+++ b/command_dialog.go
@@ -1,7 +1,5 @@
 package pctk
 
-import "time"
-
 // ShowDialog is a command that will show a dialog with the given text.
 type ShowDialog struct {
 	Actor    *Actor
@@ -12,29 +10,6 @@ type ShowDialog struct {
 }
 
 func (cmd ShowDialog) Execute(app *App, done *Promise) {
-	if cmd.Speed == 0 {
-		cmd.Speed = 1
-	}
-
-	shownDuring := time.Duration(len(cmd.Text)/LettersPerSecond) * time.Second
-	if shownDuring < 2*time.Second {
-		shownDuring = 2 * time.Second
-	}
-	shownDuring /= time.Duration(cmd.Speed)
-	expiresAt := time.Now().Add(shownDuring)
-
-	if cmd.Actor != nil {
-		app.ClearDialogsFrom(cmd.Actor)
-	}
-
-	dialog := Dialog{
-		actor:       cmd.Actor,
-		text:        cmd.Text,
-		pos:         cmd.Position,
-		color:       cmd.Color,
-		speed:       cmd.Speed,
-		completedAt: expiresAt,
-		done:        done,
-	}
-	app.dialogs = append(app.dialogs, dialog)
+	dialog := NewDialog(cmd.Actor, cmd.Text, cmd.Position, cmd.Color, cmd.Speed)
+	app.BeginDialog(dialog)
 }

--- a/dialog.go
+++ b/dialog.go
@@ -24,9 +24,24 @@ type Dialog struct {
 	pos   Position
 	color Color
 	speed float32
+	done  *Promise
+}
 
-	completedAt time.Time
-	done        *Promise
+// NewDialog creates a new dialog with the given properties.
+func NewDialog(actor *Actor, text string, pos Position, color Color, speed float32) *Dialog {
+	if color == Blank {
+		color = DefaultDialogColor
+	}
+	if speed == 0 {
+		speed = 1
+	}
+	return &Dialog{
+		actor: actor,
+		text:  text,
+		pos:   pos,
+		color: color,
+		speed: speed,
+	}
 }
 
 // Actor returns the actor that is speaking the dialog, or nil if it comes from a external voice.
@@ -34,14 +49,45 @@ func (d *Dialog) Actor() *Actor {
 	return d.actor
 }
 
-// Draw will draw the dialog in the screen. It returns true if the dialog is completed.
-func (d *Dialog) Draw() (completed bool) {
-	if time.Now().After(d.completedAt) {
-		return true
+// Begin the dialog. This will set the timer to complete the dialog.
+func (d *Dialog) Begin() {
+	duration := time.Duration(len(d.text)/LettersPerSecond) * time.Second
+	if duration < 2*time.Second {
+		duration = 2 * time.Second
 	}
+	duration /= time.Duration(d.speed)
 
+	d.done = NewPromise()
+	time.AfterFunc(duration, func() {
+		d.done.Complete()
+	})
+}
+
+// Done will return a future that will be completed when the dialog is done. If the dialog
+// is not beginned, it will return nil.
+func (d *Dialog) Done() Future {
+	if d.done == nil {
+		return nil
+	}
+	return d.done
+}
+
+// Draw will draw the dialog in the screen. It returns true if the dialog is completed.
+func (d *Dialog) Draw() {
+	if d.done != nil && d.done.IsCompleted() {
+		return
+	}
 	DrawDialogText(d.text, d.pos, d.color)
-	return false
+}
+
+// BeginDialog will prepare the dialog to be shown.
+func (a *App) BeginDialog(dialog *Dialog) {
+	dialog.Begin()
+	if actor := dialog.Actor(); actor != nil {
+		a.ClearDialogsFrom(actor)
+		actor.SetCurrentDialog(dialog)
+	}
+	a.dialogs = append(a.dialogs, *dialog)
 }
 
 // ClearDialogsFrom will remove all dialogs from the given actor.
@@ -58,9 +104,8 @@ func (a *App) ClearDialogsFrom(actor *Actor) {
 func (a *App) drawDialogs() {
 	dialogs := make([]Dialog, 0, len(a.dialogs))
 	for _, d := range a.dialogs {
-		if d.Draw() {
-			d.done.Complete()
-		} else {
+		d.Draw()
+		if !d.Done().IsCompleted() {
 			dialogs = append(dialogs, d)
 		}
 	}


### PR DESCRIPTION
Fix actor dialogs than can occur at the same time by removing dialogs from one actor when a new speak action is triggered. 

Also, ensure the standing action of an actor shows speaking animation if there is an ongoing dialog. This will ensure the actor is shown as speaking when moved after speaking. 

This is a Show PR. 