### PR TITLE
Fix random order in object states

### DIFF
--- a/examples/scene/resources/scripts/melee.lua
+++ b/examples/scene/resources/scripts/melee.lua
@@ -24,6 +24,7 @@ export {
                 anim = fixedanim { row = 6, col = 5},
             },
             pickup = state {},
+            state = "default"
         },
         clock = object {
             name = "clock",

--- a/lua.go
+++ b/lua.go
@@ -718,8 +718,7 @@ func (l *LuaInterpreter) DeclareObjectType() {
 		return
 	}
 	l.DeclareEntityConstructor(ScriptEntityObject, "object", func(l *LuaInterpreter) int {
-		obj := new(Object)
-		states := make(map[string]*ObjectState)
+		obj := NewObject()
 		l.WithEachTableItem(1, func(key string) {
 			switch key {
 			case "class":
@@ -732,6 +731,8 @@ func (l *LuaInterpreter) DeclareObjectType() {
 				obj.Pos = l.CheckEntity(-1, ScriptEntityPos).(Position)
 			case "sprites":
 				obj.Sprites = l.CheckEntity(-1, ScriptEntityRef).(ResourceRef)
+			case "state":
+				obj.State = lua.CheckString(l.State, -1)
 			case "usepos":
 				obj.UsePos = l.CheckEntity(-1, ScriptEntityPos).(Position)
 			case "usedir":
@@ -740,8 +741,7 @@ func (l *LuaInterpreter) DeclareObjectType() {
 				switch l.EntityTypeOf(-1) {
 				case ScriptEntityState:
 					st := l.CheckEntity(-1, ScriptEntityState).(*ObjectState)
-					obj.States = append(obj.States, st)
-					states[key] = st
+					obj.States[key] = st
 				default:
 					lua.ArgumentError(l.State, -1, fmt.Sprintf(
 						"unexpected field '%s' in object constructor", key))
@@ -752,7 +752,7 @@ func (l *LuaInterpreter) DeclareObjectType() {
 
 		// Set the states as fields of the object with the same key as they was declared in the
 		// constructor input.
-		for k, st := range states {
+		for k, st := range obj.States {
 			l.PushEntity(ScriptEntityState, st)
 			l.SetField(-2, k)
 		}

--- a/object.go
+++ b/object.go
@@ -5,20 +5,27 @@ import "errors"
 // Object represents an object in the game. Objects are defined in the scope of rooms and generated
 // by the room scripts.
 type Object struct {
-	CallRecv ScriptCallReceiver // The script call receiver of the object
-	Class    ObjectClass        // The classes the object belongs to as OR-ed bit flags
-	Hotspot  Rectangle          // The hotspot of the object (for mouse interaction)
-	Name     string             // The name of the object as seen by the player
-	Owner    *Actor             // The actor that owns the object, or nil if not picked up
-	Pos      Position           // The position of the object in its room (for rendering)
-	Room     *Room              // The room where the object is declared, and where actions code resides
-	Sprites  ResourceRef        // The reference to the sprites of the object
-	States   []*ObjectState     // The states the object can be in
-	UseDir   Direction          // The direction the actor when using the object
-	UsePos   Position           // The position the actor was when using the object
+	CallRecv ScriptCallReceiver      // The script call receiver of the object
+	Class    ObjectClass             // The classes the object belongs to as OR-ed bit flags
+	Hotspot  Rectangle               // The hotspot of the object (for mouse interaction)
+	Name     string                  // The name of the object as seen by the player
+	Owner    *Actor                  // The actor that owns the object, or nil if not picked up
+	Pos      Position                // The position of the object in its room (for rendering)
+	Room     *Room                   // The room where the object is declared, and where actions code resides
+	Sprites  ResourceRef             // The reference to the sprites of the object
+	State    string                  // The current state of the object
+	States   map[string]*ObjectState // The states the object can be in
+	UseDir   Direction               // The direction the actor when using the object
+	UsePos   Position                // The position the actor was when using the object
 
 	sprites *SpriteSheet // The sprites of the object
-	state   int          // The current state of the object
+}
+
+// NewObject creates a new object.
+func NewObject() *Object {
+	return &Object{
+		States: make(map[string]*ObjectState),
+	}
 }
 
 // Caption returns the name of the object.
@@ -33,10 +40,7 @@ func (o *Object) ItemClass() ObjectClass {
 
 // CurrentState returns the current state of the object.
 func (o *Object) CurrentState() *ObjectState {
-	if o.state < 0 || o.state >= len(o.States) {
-		return nil
-	}
-	return o.States[o.state]
+	return o.States[o.State]
 }
 
 // Draw renders the object in the viewport.


### PR DESCRIPTION
The bug that caused the bucket to randomly disappear was caused by the random order in which the Lua interpreter iterates over the table fields. This caused the object states to be declared in a random order. And sometimes state 0 was "default", some others it was "pickup".

This is a Show PR. 