### PR TITLE
Add minimal cicd

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Build
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.22"
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Test
+        run: go test -v -race -timeout 10s ./...
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@v3.2.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,13 +13,10 @@ jobs:
       - uses: actions/checkout@v3
 
       # from https://github.com/gen2brain/raylib-go/blob/master/.github/workflows/build.yml
-      - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y \
-          libwayland-dev \
-          libxrandr-dev \
-          libxinerama-dev \
-          libxcursor-dev \
-          libxi-dev
+      - name: Install package
+        run: |
+          sudo apt-get update -y; sudo apt-get -y install libxi-dev libxinerama-dev libxcursor-dev libxrandr-dev libgl1-mesa-dev libwayland-dev libxkbcommon-dev
+        if: runner.os == 'Linux'
 
       - name: Set up Go
         uses: actions/setup-go@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      # from https://github.com/gen2brain/raylib-go/blob/master/.github/workflows/build.yml
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y \
+          libwayland-dev \
+          libxrandr-dev \
+          libxinerama-dev \
+          libxcursor-dev \
+          libxi-dev
+
       - name: Set up Go
         uses: actions/setup-go@v4
         with:

--- a/lua_test.go
+++ b/lua_test.go
@@ -160,6 +160,7 @@ func TestDeclareRoomType(t *testing.T) {
 	l := NewLuaInterpreter()
 	lua.BaseOpen(l.State)
 
+	// TODO: Fix the deadlock running app.init() --> rl.InitWindow(...)
 	app := New(NewResourceBundle())
 	l.DeclareRoomType(app, nil)
 

--- a/lua_test.go
+++ b/lua_test.go
@@ -156,28 +156,25 @@ func TestDeclareReferenceType(t *testing.T) {
 	`))
 }
 
-/*
-// TODO: Should be fixed
+func TestDeclareRoomType(t *testing.T) {
+	l := NewLuaInterpreter()
+	lua.BaseOpen(l.State)
 
-	func TestDeclareRoomType(t *testing.T) {
-		l := NewLuaInterpreter()
-		lua.BaseOpen(l.State)
+	app := New(NewResourceBundle())
+	l.DeclareRoomType(app, nil)
 
-		app := New(NewResourceBundle())
-		l.DeclareRoomType(app, nil)
+	assert.NoError(t, lua.DoString(l.State, `
+		r = room { 
+			background = ref("resources:/backgrounds/foobar"),
+			window = object {
+				name = "broken window",
+			},
+		}
+		assert(r.background == ref("resources:/backgrounds/foobar"))
+		assert(r.window.name == "broken window")
+	`))
+}
 
-		assert.NoError(t, lua.DoString(l.State, `
-			r = room {
-				background = ref("resources:/backgrounds/foobar"),
-				window = object {
-					name = "broken window",
-				},
-			}
-			assert(r.background == ref("resources:/backgrounds/foobar"))
-			assert(r.window.name == "broken window")
-		`))
-	}
-*/
 func TestDeclareSizeType(t *testing.T) {
 	l := NewLuaInterpreter()
 	lua.BaseOpen(l.State)

--- a/lua_test.go
+++ b/lua_test.go
@@ -156,25 +156,28 @@ func TestDeclareReferenceType(t *testing.T) {
 	`))
 }
 
-func TestDeclareRoomType(t *testing.T) {
-	l := NewLuaInterpreter()
-	lua.BaseOpen(l.State)
+/*
+// TODO: Should be fixed
 
-	app := New(NewResourceBundle())
-	l.DeclareRoomType(app, nil)
+	func TestDeclareRoomType(t *testing.T) {
+		l := NewLuaInterpreter()
+		lua.BaseOpen(l.State)
 
-	assert.NoError(t, lua.DoString(l.State, `
-		r = room { 
-			background = ref("resources:/backgrounds/foobar"),
-			window = object {
-				name = "broken window",
-			},
-		}
-		assert(r.background == ref("resources:/backgrounds/foobar"))
-		assert(r.window.name == "broken window")
-	`))
-}
+		app := New(NewResourceBundle())
+		l.DeclareRoomType(app, nil)
 
+		assert.NoError(t, lua.DoString(l.State, `
+			r = room {
+				background = ref("resources:/backgrounds/foobar"),
+				window = object {
+					name = "broken window",
+				},
+			}
+			assert(r.background == ref("resources:/backgrounds/foobar"))
+			assert(r.window.name == "broken window")
+		`))
+	}
+*/
 func TestDeclareSizeType(t *testing.T) {
 	l := NewLuaInterpreter()
 	lua.BaseOpen(l.State)

--- a/lua_test.go
+++ b/lua_test.go
@@ -157,10 +157,10 @@ func TestDeclareReferenceType(t *testing.T) {
 }
 
 func TestDeclareRoomType(t *testing.T) {
+	// TODO
+	t.Skip("Fix the deadlock running app.init() --> rl.InitWindow(...)")
 	l := NewLuaInterpreter()
 	lua.BaseOpen(l.State)
-
-	// TODO: Fix the deadlock running app.init() --> rl.InitWindow(...)
 	app := New(NewResourceBundle())
 	l.DeclareRoomType(app, nil)
 


### PR DESCRIPTION
# Situation

To ensure quality of the code. 
The pipeline is gonna be executed but it is pending to check the option **Require status checks to pass before merging**.  Before activate this rule, we should fix:

- Unit tests is failing

```console
panic: test timed out after 10s
running tests:
        TestDeclareRoomType (10s)
...
```

The problem is with rl.InitWindow

- Linter is failing

```console
lua.go:194:27: Error return value of `(github.com/apoloval/pctk.Future).Wait` is not checked (errcheck)
                app.RunCommand(cmd).Wait()
                                        ^
lua.go:211:27: Error return value of `(github.com/apoloval/pctk.Future).Wait` is not checked (errcheck)
                app.RunCommand(cmd).Wait()
                                        ^
lua.go:223:27: Error return value of `(github.com/apoloval/pctk.Future).Wait` is not checked (errcheck)
                app.RunCommand(cmd).Wait()
                                        ^
lua.go:616:9: Error return value of `f.Wait` is not checked (errcheck)
                f.Wait()
                      ^
app.go:18:2: field `objects` is unused (unused)
        objects  []*Object
        ^
app.go:27:2: field `cursorTx` is unused (unused)
        cursorTx    rl.Texture2D
        ^
app.go:28:2: field `cursorColor` is unused (unused)
        cursorColor Color
        ^
app.go:30:2: field `sound` is unused (unused)
        sound       *Sound
        ^
space.go:217:15: func `Size.toRaylib` is unused (unused)
func (s Size) toRaylib() rl.Vector2 {
              ^
walkbox.go:186:26: func `(*WalkBoxMatrix).nextWalkBox` is unused (unused)
func (wm *WalkBoxMatrix) nextWalkBox(from, to int) int {
                         ^
walkbox.go:195:26: func `(*WalkBoxMatrix).walkBoxAt` is unused (unused)
func (wm *WalkBoxMatrix) walkBoxAt(p *Positionf) (id int, included bool) {
                         ^
walkbox.go:201:26: func `(*WalkBoxMatrix).closestPositionToWalkBox` is unused (unused)
func (wm *WalkBoxMatrix) closestPositionToWalkBox(from, to int) *Positionf {
                         ^
walkbox.go:206:26: func `(*WalkBoxMatrix).closestPositionOnWalkBox` is unused (unused)
func (wm *WalkBoxMatrix) closestPositionOnWalkBox(p *Positionf) *Positionf {
                         ^
anim.go:51:5: ineffectual assignment to err (ineffassign)
        n, err = BinaryEncode(w, a.flip, uint32(len(a.frames)))
           ^
costume.go:55:5: ineffectual assignment to err (ineffassign)
        n, err = BinaryEncode(w, c.sprites, uint32(len(c.anims)))
           ^
command_actor.go:242:3: SA4005: ineffective assignment to field ActorSpeak.Delay (staticcheck)
                cmd.Delay = DefaultActorSpeakDelay
```

☝️ issues related to Walkboxes should be fixes automatically after merfing https://github.com/apoloval/pctk/pull/30