### PR TITLE
Draw walkboxes when debug mode is enabled

### DIFF
--- a/room.go
+++ b/room.go
@@ -40,7 +40,7 @@ func (r *Room) DeclareWalkBoxMatrix(walkboxes []*WalkBox) {
 }
 
 // Draw renders the room in the viewport.
-func (r *Room) Draw(debugMode bool) {
+func (r *Room) Draw(debugEnabled bool) {
 	r.background.Draw(NewPos(0, 0), White)
 	items := make([]RoomItem, 0, len(r.actors)+len(r.objects))
 	for _, actor := range r.actors {
@@ -56,7 +56,7 @@ func (r *Room) Draw(debugMode bool) {
 		item.Draw()
 	}
 
-	if debugMode && r.wbmatrix != nil {
+	if debugEnabled && r.wbmatrix != nil {
 		r.wbmatrix.Draw()
 	}
 }

--- a/room.go
+++ b/room.go
@@ -170,6 +170,6 @@ func (a *App) StartRoom(room *Room) Future {
 
 func (a *App) drawSceneViewport() {
 	if a.room != nil {
-		a.room.Draw(a.debugMode)
+		a.room.Draw(a.debugEnabled)
 	}
 }

--- a/room.go
+++ b/room.go
@@ -40,7 +40,7 @@ func (r *Room) DeclareWalkBoxMatrix(walkboxes []*WalkBox) {
 }
 
 // Draw renders the room in the viewport.
-func (r *Room) Draw() {
+func (r *Room) Draw(debugMode bool) {
 	r.background.Draw(NewPos(0, 0), White)
 	items := make([]RoomItem, 0, len(r.actors)+len(r.objects))
 	for _, actor := range r.actors {
@@ -54,6 +54,10 @@ func (r *Room) Draw() {
 	})
 	for _, item := range items {
 		item.Draw()
+	}
+
+	if debugMode {
+		r.wbmatrix.Draw()
 	}
 }
 
@@ -166,6 +170,6 @@ func (a *App) StartRoom(room *Room) Future {
 
 func (a *App) drawSceneViewport() {
 	if a.room != nil {
-		a.room.Draw()
+		a.room.Draw(a.debugMode)
 	}
 }

--- a/room.go
+++ b/room.go
@@ -56,7 +56,7 @@ func (r *Room) Draw(debugMode bool) {
 		item.Draw()
 	}
 
-	if debugMode {
+	if debugMode && r.wbmatrix != nil {
 		r.wbmatrix.Draw()
 	}
 }


### PR DESCRIPTION
Current issue link the debug mode feature with walkboxes allowing us to render walkboxes defined in the room for testing / debugging purposes.