### PR TITLE
add sequenceanim for objects

### DIFF
--- a/examples/scene/resources/scripts/melee.decl.lua
+++ b/examples/scene/resources/scripts/melee.decl.lua
@@ -58,7 +58,10 @@ export {
             usedir = RIGHT,
             usepos = pos {x=240, y=120},
             default = state {
-                anim = fixedanim { row = 6, col = 5},
+                anim = sequenceanim { 
+                    duration = 100,
+                    row = 6, 
+                    columns = {5}},
             },
             pickup = state {},
             state = "default"

--- a/lua.go
+++ b/lua.go
@@ -78,6 +78,17 @@ func (l *LuaInterpreter) CheckFieldInteger(index int, name string) (val int) {
 	return
 }
 
+// CheckFieldIntegersArray checks if the field of the table at index is an array of integer, and returns it.
+func (l *LuaInterpreter) CheckFieldIntegersArray(index int, name string) (values []int) {
+	l.Field(index, name)
+	l.PushNil()
+	for l.Next(-2) {
+		values = append(values, int(lua.CheckInteger(l.State, -1)))
+		l.Pop(1)
+	}
+	return
+}
+
 // CheckFieldEntity checks if the field of the table at index is an entity of the given type, and
 // returns it.
 func (l *LuaInterpreter) CheckFieldEntity(index int, name string, typ ScriptEntityType) (val any) {
@@ -231,6 +242,19 @@ func (l *LuaInterpreter) DeclareAnimType() {
 			1*time.Second,
 			l.CheckFieldInteger(1, "row"),
 			l.CheckFieldInteger(1, "col"),
+		)
+		l.PushEntity(ScriptEntityAnimation, anim)
+		return 1
+	})
+	l.DeclareEntityConstructor(ScriptEntityAnimation, "sequenceanim", func(l *LuaInterpreter) int {
+		anim := NewAnimation()
+		duration := l.CheckFieldInteger(1, "duration")
+		row := l.CheckFieldInteger(1, "row")
+		cols := l.CheckFieldIntegersArray(-1, "columns")
+		anim.AddFrames(
+			time.Duration(duration)*time.Millisecond,
+			row,
+			cols...,
 		)
 		l.PushEntity(ScriptEntityAnimation, anim)
 		return 1

--- a/lua.go
+++ b/lua.go
@@ -250,7 +250,7 @@ func (l *LuaInterpreter) DeclareAnimType() {
 		anim := NewAnimation()
 		duration := l.CheckFieldInteger(1, "duration")
 		row := l.CheckFieldInteger(1, "row")
-		cols := l.CheckFieldIntegersArray(-1, "columns")
+		cols := l.CheckFieldIntegersArray(1, "columns")
 		anim.AddFrames(
 			time.Duration(duration)*time.Millisecond,
 			row,


### PR DESCRIPTION
Allow anim objects using `sequenceanim`:

```lua
bucket = object {
            class = APPLICABLE,
            name = "bucket",
            sprites = ref("resources:sprites/objects"),
            pos = pos {x=260, y=120},
            hotspot = rect {x=250, y=100, w=20, h=20},
            usedir = RIGHT,
            usepos = pos {x=240, y=120},
            default = state {
                anim = sequenceanim { 
                    duration = 100,
                    row = 6, 
                    columns = {5,6}},
            },
            pickup = state {},
            state = "default"
        },
```