### PR TITLE
Fix wrongly positioned dialogs

### DIFF
--- a/command_dialog.go
+++ b/command_dialog.go
@@ -11,6 +11,10 @@ type ShowDialog struct {
 
 func (cmd ShowDialog) Execute(app *App, done *Promise) {
 	dialog := NewDialog(cmd.Actor, cmd.Text, cmd.Position, cmd.Color, cmd.Speed)
+	if room := cmd.Actor.Room; room != nil {
+		dialog.SetBounds(room.Rect())
+	}
+
 	app.viewport.BeginDialog(dialog)
 	done.Bind(dialog.Done())
 }

--- a/dialog.go
+++ b/dialog.go
@@ -19,12 +19,13 @@ var (
 
 // Dialog is a dialog that will be shown in the screen.
 type Dialog struct {
-	actor *Actor
-	text  string
-	pos   Position
-	color Color
-	speed float32
-	done  *Promise
+	actor  *Actor
+	bounds Rectangle
+	text   string
+	pos    Position
+	color  Color
+	speed  float32
+	done   *Promise
 }
 
 // NewDialog creates a new dialog with the given properties.
@@ -42,6 +43,11 @@ func NewDialog(actor *Actor, text string, pos Position, color Color, speed float
 		color: color,
 		speed: speed,
 	}
+}
+
+// SetBounds sets the bounds of the dialog.
+func (d *Dialog) SetBounds(bounds Rectangle) {
+	d.bounds = bounds
 }
 
 // Actor returns the actor that is speaking the dialog, or nil if it comes from a external voice.
@@ -77,5 +83,5 @@ func (d *Dialog) Draw() {
 	if d.done != nil && d.done.IsCompleted() {
 		return
 	}
-	DrawDialogText(d.text, d.pos, d.color)
+	DrawDialogText(d.text, d.pos, d.bounds, d.color)
 }

--- a/examples/scene/resources/scripts/melee.decl.lua
+++ b/examples/scene/resources/scripts/melee.decl.lua
@@ -53,10 +53,10 @@ export {
             class = APPLICABLE,
             name = "bucket",
             sprites = ref("resources:sprites/objects"),
-            pos = pos {x=260, y=120},
-            hotspot = rect {x=250, y=100, w=20, h=20},
+            pos = pos {x=440, y=130},
+            hotspot = rect {x=430, y=110, w=20, h=20},
             usedir = RIGHT,
-            usepos = pos {x=240, y=120},
+            usepos = pos {x=420, y=130},
             default = state {
                 anim = sequenceanim { 
                     duration = 100,

--- a/font.go
+++ b/font.go
@@ -16,8 +16,8 @@ const (
 	// FontDialogSpacing is the spacing between glyphs in the dialog font.
 	FontDialogSpacing = -1
 
-	// DialogScreenMarging is the margin of the screen left by the dialog.
-	DialogScreenMarging = 10
+	// DialogBoundsMargin is the margin of the bounds left by the dialog.
+	DialogBoundsMargin = 10
 )
 
 type TextAlignment int
@@ -78,8 +78,12 @@ func DrawDefaultText(text string, pos Position, align TextAlignment, color Color
 }
 
 // DrawDialogText draws text using the dialog font.
-func DrawDialogText(text string, pos Position, color Color) {
+func DrawDialogText(text string, pos Position, bounds Rectangle, color Color) {
 	fontSolid, fontOutline := FontDialog()
+
+	if bounds.IsZero() {
+		bounds = NewRect(0, 0, ScreenWidth, ScreenHeight)
+	}
 
 	lines := strings.Split(text, "\n")
 	for i, line := range lines {
@@ -87,11 +91,11 @@ func DrawDialogText(text string, pos Position, color Color) {
 		tsize := sizeFromRaylib(rl.MeasureTextEx(fontOutline, line, FontDialogSize, FontDialogSpacing))
 		tw := tsize.W
 
-		if pos.X-tw/2 < DialogScreenMarging {
-			pos.X = tw/2 + DialogScreenMarging
+		if pos.X-tw/2 < bounds.LeftEdge()+DialogBoundsMargin {
+			pos.X = tw/2 + bounds.LeftEdge() + DialogBoundsMargin
 		}
-		if pos.X+tw/2 > ScreenWidth-DialogScreenMarging {
-			pos.X = ScreenWidth - tw/2 - DialogScreenMarging
+		if pos.X+tw/2 > bounds.RightEdge()-DialogBoundsMargin {
+			pos.X = bounds.RightEdge() - tw/2 - DialogBoundsMargin
 		}
 
 		rl.DrawTextEx(

--- a/space.go
+++ b/space.go
@@ -275,6 +275,31 @@ func NewRect(x, y, w, h int) Rectangle {
 	}
 }
 
+// IsZero returns true if the rectangle is empty.
+func (r Rectangle) IsZero() bool {
+	return r.Pos.X == 0 && r.Pos.Y == 0 && r.Size.W == 0 && r.Size.H == 0
+}
+
+// LeftEdge returns the X coordinate of the left edge of the rectangle.
+func (r Rectangle) LeftEdge() int {
+	return r.Pos.X
+}
+
+// RightEdge returns the X coordinate of the right edge of the rectangle.
+func (r Rectangle) RightEdge() int {
+	return r.Pos.X + r.Size.W
+}
+
+// TopEdge returns the Y coordinate of the top edge of the rectangle.
+func (r Rectangle) TopEdge() int {
+	return r.Pos.Y
+}
+
+// BottomEdge returns the Y coordinate of the bottom edge of the rectangle.
+func (r Rectangle) BottomEdge() int {
+	return r.Pos.Y + r.Size.H
+}
+
 func (r Rectangle) String() string {
 	return fmt.Sprintf("(Pos:%v, Size:%v)", r.Pos, r.Size)
 }


### PR DESCRIPTION
Dialogs were implemented to avoid the text was not out of screen coordinates. But since we introduced camera movements, dialogs have to consider the room bounds when rendered.

This is a Show PR. 